### PR TITLE
Fixed mismatch of preview in the pattern of a particular

### DIFF
--- a/autoload/unite/sources/hoogle.vim
+++ b/autoload/unite/sources/hoogle.vim
@@ -24,7 +24,7 @@ function! s:source.gather_candidates(args, context)
 endfunction
 
 function! s:make_candidate(input, index, line, exact)
-  let l:line = matchstr(a:line, '^.\+\ze -- http://')
+  let l:line = matchstr(a:line, '^.\+\ze -- \(\(http\|file\)://\)\?')
   let l:candidate = {
         \ 'word': a:input,
         \ 'abbr': l:line,
@@ -32,8 +32,8 @@ function! s:make_candidate(input, index, line, exact)
         \ 'kind': 'haddock',
         \ 'action__haddock_module': '',
         \ 'action__haddock_fragment': '',
-        \ 'action__haddock_index': 1,
-        \ 'action__haddock_exact': 0,
+        \ 'action__haddock_index': a:index,
+        \ 'action__haddock_exact': a:exact,
         \ }
   let l:m = matchlist(a:line, '^\(\S\+\)\s\+\(\S\+\)\(.*\)$')
   if empty(l:m)
@@ -41,8 +41,6 @@ function! s:make_candidate(input, index, line, exact)
   endif
 
   let [l:mod, l:sym, l:rest] = l:m[1 : 3]
-  let l:candidate.action__haddock_index = a:index
-  let l:candidate.action__haddock_exact = a:exact
   if l:mod ==# 'package'
     return l:candidate
   else

--- a/autoload/unite/sources/hoogle.vim
+++ b/autoload/unite/sources/hoogle.vim
@@ -17,7 +17,18 @@ function! s:source.gather_candidates(args, context)
   let l:exact = !empty(filter(copy(a:args), 'v:val ==# "exact"'))
   let l:output = unite#util#system(printf('hoogle search --link --count %d %s%s', s:max_candidates(), s:exact_flag(l:exact), shellescape(a:context.input)))
   if unite#util#get_last_status() == 0
-    return map(split(l:output, '\n'), 's:make_candidate(a:context.input, v:key, v:val, l:exact)')
+    let l:lines = split(l:output, '\n')
+    let l:start_pos = 0
+    if a:context.input =~# '^\s*.oogle\s*$'
+      let l:start_pos += 1
+    endif
+    if stridx(l:lines[l:start_pos], 'Did you mean: ') == 0
+      let l:start_pos += 1
+    endif
+    if stridx(l:lines[l:start_pos], 'No results found') == 0
+      let l:start_pos += 1
+    endif
+    return map(l:lines[l:start_pos :], 's:make_candidate(a:context.input, v:key, v:val, l:exact)')
   else
     return []
   endif


### PR DESCRIPTION
hoogle command because the output is extra message when you search for
a particular query, the preview does not match the candidate.
For this reason, it is skipped extra message.

The following is a specific pattern and its source.

https://github.com/ndmitchell/hoogle/blob/master/src/Hoogle/Query/Suggest.hs

case 1: Search Google

``` output:
Google rocks!
```

case 2: Search ?oogle (ex. hoogle)

``` output:
Can't think of anything more interesting to search for?
```

case 3: Suggestion message of "Did you mean: " (ex. search "IO String")

``` output:
Did you mean: :: IO String
```

case 4: None search result (ex. search "foo-bar-baz")

``` output:
No results found
```

case 5: Conbination of case 2 and case 4 (ex. coogle)

``` output:
Can't think of anything more interesting to search for?
No results found
```
